### PR TITLE
Update CKAN link to repo

### DIFF
--- a/CKAN/NearFutureProps.netkan
+++ b/CKAN/NearFutureProps.netkan
@@ -9,7 +9,7 @@
     "license":        "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166941-*",
-        "repository": "https://github.com/post-kerbin-mining-corporation/NearFutureElectrical"
+        "repository": "https://github.com/post-kerbin-mining-corporation/NearFutureProps"
     },
     "supports": [
         { "name": "NearFutureSpacecraft"  },


### PR DESCRIPTION
Hi @ChrisAdderley,

This mod's repository link in CKAN currently points to the repo for Near Future Electrical. (I wanted to read some prop configs and was confused when I didn't find them.)

Now it's fixed.

Cheers!
